### PR TITLE
Ezra/jmes basic expression support

### DIFF
--- a/tree_tools/src/jtt_query/operations.py
+++ b/tree_tools/src/jtt_query/operations.py
@@ -3,17 +3,18 @@ from typing import Optional, Generator
 
 from tree_tools.src import jtt_tree
 
+
 class QueryOperationError(Exception):
     pass
 
 
-class QueryOperation: 
+class QueryOperation:
     """
-    Represents a single operation in an operation chain. 
+    Represents a single operation in an operation chain.
     """
-    
-    next: Optional['QueryOperation']
-    
+
+    next: Optional["QueryOperation"]
+
     @abstractmethod
     def perform(self, node: jtt_tree.TreeNode) -> Optional[jtt_tree.TreeNode]:
         """
@@ -22,70 +23,69 @@ class QueryOperation:
         """
         pass
 
-    
+
 class KeySelectOperation(QueryOperation):
     """
-    This class is used to represent the key selection in a query.  
+    This class is used to represent the key selection in a query.
     A key selection only applies to ObjectTreeNodes and returns the TreeNode stored at the specified key.
     """
 
     key: str
-    
+
     def __init__(self, key: str) -> None:
         self.key = key
         self.next = None
-        
+
     def perform(self, node: jtt_tree.TreeNode) -> Optional[jtt_tree.TreeNode]:
         """
-        If the node is a dictionary, return the value at the key. 
+        If the node is a dictionary, return the value at the key.
         Otherwise, return nothing
         """
         if node.type == jtt_tree.NodeType.OBJECT:
             return node.value.get(self.key, None)
         else:
             return None
-        
+
+
 class QueryOperationChain:
     """
     This class is used to represent the operations in a query in proper order.
-    An operation chain, when executed, should resolve to a ObjectTreeNode that contains the valid 
+    An operation chain, when executed, should resolve to a ObjectTreeNode that contains the valid
     results.
     """
-    
+
     head: Optional[QueryOperation]
-    
+
     def __init__(self) -> None:
         self.head = None
 
-
-        
     def append(self, op: QueryOperation) -> None:
         """
         Append an operation to the end of the chain, including any downstream attached operations.
-        
+
         Args:
             op: The operation to append.
         """
-        
+
         if not self.head:
             self.head = op
-            return 
-          
+            return
+
         current = self.head
         while current.next:
             current = current.next
-        current.next = op 
-        
+        current.next = op
+
     def has_next(self) -> bool:
         """
         Returns True if there are more operations to perform.
         """
-        return self.head is not None    
-    
+        return self.head is not None
+
     def pop_operation(self) -> Optional[QueryOperation]:
         """
         Removes the first operation from the chain and returns it.
-        
+
         Args:
             tree: The TreeNode to perform the operation on.
         """
@@ -94,16 +94,16 @@ class QueryOperationChain:
             self.head = self.head.next
             return op
         return None
-    
+
     def __iter__(self) -> Generator[QueryOperation, None, None]:
         """
         Returns a generator that yields each operation in the chain.
         This is a destructive operation as each yield calls pop_operation.
         """
-        
+
         while self.has_next():
             yield self.pop_operation()
-            
+
     def __len__(self) -> int:
         """
         Returns the number of operations in the chain.
@@ -114,4 +114,3 @@ class QueryOperationChain:
             count += 1
             current = current.next
         return count
-    

--- a/tree_tools/src/jtt_query/operations.py
+++ b/tree_tools/src/jtt_query/operations.py
@@ -35,7 +35,7 @@ class KeySelectOperation(QueryOperation):
         self.key = key
         self.next = None
         
-    def perform(self, node: jtt_tree.TreeNode) -> jtt_tree.TreeNode:
+    def perform(self, node: jtt_tree.TreeNode) -> Optional[jtt_tree.TreeNode]:
         """
         If the node is a dictionary, return the value at the key. 
         Otherwise, return nothing
@@ -44,7 +44,6 @@ class KeySelectOperation(QueryOperation):
             return node.value.get(self.key, None)
         else:
             return None
-        
         
 class QueryOperationChain:
     """
@@ -58,16 +57,7 @@ class QueryOperationChain:
     def __init__(self) -> None:
         self.head = None
 
-    def __len__(self) -> int:
-        """
-        Returns the number of operations in the chain.
-        """
-        count = 0
-        current = self.head
-        while current:
-            count += 1
-            current = current.next
-        return count
+
         
     def append(self, op: QueryOperation) -> None:
         """
@@ -105,7 +95,7 @@ class QueryOperationChain:
             return op
         return None
     
-    def operations(self) -> Generator[QueryOperation, None, None]:
+    def __iter__(self) -> Generator[QueryOperation, None, None]:
         """
         Returns a generator that yields each operation in the chain.
         This is a destructive operation as each yield calls pop_operation.
@@ -113,3 +103,15 @@ class QueryOperationChain:
         
         while self.has_next():
             yield self.pop_operation()
+            
+    def __len__(self) -> int:
+        """
+        Returns the number of operations in the chain.
+        """
+        count = 0
+        current = self.head
+        while current:
+            count += 1
+            current = current.next
+        return count
+    

--- a/tree_tools/src/jtt_query/parsing.py
+++ b/tree_tools/src/jtt_query/parsing.py
@@ -41,9 +41,6 @@ class JMESPathParser:
         if not PATTERN_START_WITH_WORD.match(query) and not PATTERN_QUOTE_CHARACTERS.match(query):
             raise JMESPathValidationError("Query string must start with a word character or a quote character.")
     
-        
-    
-    
     def tokenize(self, query: str) -> None:
         """
         This method breaks up a query string into tokens using expected delimiters and special symbols. 
@@ -54,7 +51,9 @@ class JMESPathParser:
         """
         
         if '.' in query:
-            self.identifiers = query.split('.')            
+            self.identifiers = query.split('.')
+        else:
+            self.identifiers.append(query)            
             
     def create_query_operations(self) -> None:
         """

--- a/tree_tools/src/jtt_query/parsing.py
+++ b/tree_tools/src/jtt_query/parsing.py
@@ -1,11 +1,11 @@
 from typing import List
-import re 
+import re
 
 
 from tree_tools.src.jtt_query.operations import QueryOperationChain, KeySelectOperation
 
 
-PATTERN_START_WITH_WORD = re.compile(r'[a-zA-Z_]+')
+PATTERN_START_WITH_WORD = re.compile(r"[a-zA-Z_]+")
 PATTERN_QUOTE_CHARACTERS = re.compile(r'["\']')
 
 
@@ -18,43 +18,46 @@ class JMESPathParser:
     This class is used to parse JMESPath query strings into query operations to execute.
     JMESPath is a query language for JSON-like data, explained in detail at https://jmespath.org/.
     """
+
     identifiers: List[str]
     operation_queue: QueryOperationChain
-    
-    
+
     def __init__(self) -> None:
-        
         self.identifiers = []
         self.operation_queue = QueryOperationChain()
-        
+
     def validate_query(self, query: str) -> None:
         """
         This method is used to validate a query string to ensure it is a valid JMESPath query.
         Raises JMESPathValidationError if the query is invalid.
-        
+
         Args:
             query: The query string to validate.
         """
         if not query:
             raise JMESPathValidationError("Query string cannot be empty.")
-        
-        if not PATTERN_START_WITH_WORD.match(query) and not PATTERN_QUOTE_CHARACTERS.match(query):
-            raise JMESPathValidationError("Query string must start with a word character or a quote character.")
-    
+
+        if not PATTERN_START_WITH_WORD.match(
+            query
+        ) and not PATTERN_QUOTE_CHARACTERS.match(query):
+            raise JMESPathValidationError(
+                "Query string must start with a word character or a quote character."
+            )
+
     def tokenize(self, query: str) -> None:
         """
-        This method breaks up a query string into tokens using expected delimiters and special symbols. 
-        A query string is processed from left to right.  
-        
-        Args: 
+        This method breaks up a query string into tokens using expected delimiters and special symbols.
+        A query string is processed from left to right.
+
+        Args:
             query: The query string to tokenize.
         """
-        
-        if '.' in query:
-            self.identifiers = query.split('.')
+
+        if "." in query:
+            self.identifiers = query.split(".")
         else:
-            self.identifiers.append(query)            
-            
+            self.identifiers.append(query)
+
     def create_query_operations(self) -> None:
         """
         This method creates query objects from stored tokens and adds them to the operation queue.
@@ -62,24 +65,17 @@ class JMESPathParser:
         for identifier in self.identifiers:
             key_operation = KeySelectOperation(identifier)
             self.operation_queue.append(key_operation)
-            
-    
+
     def parse(self, query: str) -> QueryOperationChain:
         """
         Main method to parse a query string into a query chain.
         This calls validate_query, and may raise a JMESPathValidationError.
-        
+
         Args:
             query: The query string to parse.
         """
-        
+
         self.validate_query(query)
         self.tokenize(query)
         self.create_query_operations()
         return self.operation_queue
-
-            
-
-
-
-

--- a/tree_tools/src/jtt_query/parsing.py
+++ b/tree_tools/src/jtt_query/parsing.py
@@ -1,0 +1,86 @@
+from typing import List
+import re 
+
+
+from tree_tools.src.jtt_query.operations import QueryOperationChain, KeySelectOperation
+
+
+PATTERN_START_WITH_WORD = re.compile(r'[a-zA-Z_]+')
+PATTERN_QUOTE_CHARACTERS = re.compile(r'["\']')
+
+
+class JMESPathValidationError(Exception):
+    pass
+
+
+class JMESPathParser:
+    """
+    This class is used to parse JMESPath query strings into query operations to execute.
+    JMESPath is a query language for JSON-like data, explained in detail at https://jmespath.org/.
+    """
+    identifiers: List[str]
+    operation_queue: QueryOperationChain
+    
+    
+    def __init__(self) -> None:
+        
+        self.identifiers = []
+        self.operation_queue = QueryOperationChain()
+        
+    def validate_query(self, query: str) -> None:
+        """
+        This method is used to validate a query string to ensure it is a valid JMESPath query.
+        Raises JMESPathValidationError if the query is invalid.
+        
+        Args:
+            query: The query string to validate.
+        """
+        if not query:
+            raise JMESPathValidationError("Query string cannot be empty.")
+        
+        if not PATTERN_START_WITH_WORD.match(query) and not PATTERN_QUOTE_CHARACTERS.match(query):
+            raise JMESPathValidationError("Query string must start with a word character or a quote character.")
+    
+        
+    
+    
+    def tokenize(self, query: str) -> None:
+        """
+        This method breaks up a query string into tokens using expected delimiters and special symbols. 
+        A query string is processed from left to right.  
+        
+        Args: 
+            query: The query string to tokenize.
+        """
+        
+        if '.' in query:
+            self.identifiers = query.split('.')            
+            
+    def create_query_operations(self) -> None:
+        """
+        This method creates query objects from stored tokens and adds them to the operation queue.
+        """
+        for identifier in self.identifiers:
+            key_operation = KeySelectOperation(identifier)
+            self.operation_queue.append(key_operation)
+            
+    
+    def parse(self, query: str) -> QueryOperationChain:
+        """
+        Main method to parse a query string into a query chain.
+        This calls validate_query, and may raise a JMESPathValidationError.
+        
+        Args:
+            query: The query string to parse.
+        """
+        
+        self.validate_query(query)
+        self.tokenize(query)
+        self.create_query_operations()
+        return self.operation_queue
+
+            
+
+
+
+

--- a/tree_tools/src/jtt_query/queries.py
+++ b/tree_tools/src/jtt_query/queries.py
@@ -11,20 +11,21 @@ class NodeQueryError(Exception):
 
     pass
 
-class Cursor: 
+
+class Cursor:
     """
     This class is used to represent the current position in the tree during query processing.
     """
+
     node: Optional[jtt_tree.TreeNode]
-    
+
     def __init__(self) -> None:
         self.node = None
-        
-        
+
     def visit(self, node: jtt_tree.TreeNode) -> None:
         """
         Move the cursor to the specified node.
-        
+
         Args:
             node: The TreeNode to move the cursor to.
         """
@@ -35,18 +36,21 @@ class QueryProcessor:
     """
     This class is used to evaluate queries against TreeNode objects.
     """
+
     operation_chain: operations.QueryOperationChain
     result_tree: jtt_tree.TreeNode
     read_tree: jtt_tree.TreeNode
     cursor: Cursor
-    
-    def __init__(self, tree: jtt_tree.TreeNode, operation_chain: operations.QueryOperationChain) -> None:
+
+    def __init__(
+        self, tree: jtt_tree.TreeNode, operation_chain: operations.QueryOperationChain
+    ) -> None:
         self.read_tree = tree
         self.result_tree = None
         self.operation_chain = operation_chain
         self.cursor = Cursor()
         self.cursor.visit(self.read_tree)
-    
+
     def execute(self) -> jtt_tree.TreeNode:
         """
         Execute the query operations and store the result in the result_tree attribute.
@@ -56,9 +60,6 @@ class QueryProcessor:
             if not self.cursor.node:
                 self.result_tree = jtt_tree.NullTreeNode()
                 return self.result_tree
-            
+
         self.result_tree = self.cursor.node
         return self.result_tree
-
-
-

--- a/tree_tools/src/jtt_query/queries.py
+++ b/tree_tools/src/jtt_query/queries.py
@@ -1,5 +1,4 @@
-import typing
-from collections import deque
+from typing import Optional
 
 from tree_tools.src import jtt_tree
 from tree_tools.src.jtt_query import operations
@@ -16,7 +15,20 @@ class Cursor:
     """
     This class is used to represent the current position in the tree during query processing.
     """
-    pass
+    node: Optional[jtt_tree.TreeNode]
+    
+    def __init__(self) -> None:
+        self.node = None
+        
+        
+    def visit(self, node: jtt_tree.TreeNode) -> None:
+        """
+        Move the cursor to the specified node.
+        
+        Args:
+            node: The TreeNode to move the cursor to.
+        """
+        self.node = node
 
 
 class QueryProcessor:
@@ -33,128 +45,20 @@ class QueryProcessor:
         self.result_tree = None
         self.operation_chain = operation_chain
         self.cursor = Cursor()
+        self.cursor.visit(self.read_tree)
     
-    pass 
-
-
-class NodeQuery:
-
-    """
-    This class is used to build and evaluate queries against TreeNode objects.
-    """
-
-    op_queue: typing.Deque[operations.QueryOperation]
-    tree: jtt_tree.TreeNode
-    results: typing.List[jtt_tree.TreeNode]
-
-    def __init__(self, tree: jtt_tree.TreeNode) -> None:
-        self.tree = tree
-        self.op_queue = deque()
-        self.results = []
-
-    def _process_op(self, node: jtt_tree.TreeNode) -> typing.List[jtt_tree.TreeNode]:
+    def execute(self) -> jtt_tree.TreeNode:
         """
-        Process the next query operation.
+        Execute the query operations and store the result in the result_tree attribute.
         """
-        if not self.op_queue:
-            raise NodeQueryError("Nothing left to evaluate, query path is empty.")
-        query_op = self.op_queue.popleft()
-        return query_op.evaluate(node)
-
-    def collect_results(self) -> typing.List[jtt_tree.TreeNode]:
-        """
-        Collect the results of the query by triggering the visitation.
-        """
-        self.tree.accept_visitor(self)
-        return self.results
-
-    def copy_query_to_new_node(self, node: jtt_tree.TreeNode) -> "NodeQuery":
-        """
-        Copy the query to a new node with the same operations.
-        """
-        new_query = NodeQuery(node)
-        new_query.op_queue = self.op_queue.copy()
-        return new_query
-
-    def visit_null_node(self, node: jtt_tree.NullTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        self.results.extend(self._process_op(node))
-
-    def visit_string_node(self, node: jtt_tree.StringTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        self.results.extend(self._process_op(node))
-
-    def visit_number_node(self, node: jtt_tree.NumberTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        self.results.extend(self._process_op(node))
-
-    def visit_boolean_node(self, node: jtt_tree.BooleanTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        self.results.extend(self._process_op(node))
-
-    def visit_array_node(self, node: jtt_tree.ListTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query, and then recurse on each result.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        for child in self._process_op(node):
-            new_query = self.copy_query_to_new_node(child)
-            self.results.extend(new_query.collect_results())
-
-    def visit_object_node(self, node: jtt_tree.ObjectTreeNode) -> None:
-        """
-        Add the node to the results if the path is empty.
-        Otherwise, evaluate according to the query, and then recurse on each result.
-        """
-        if not self.op_queue:
-            self.results.append(node)
-            return
-        for child in self._process_op(node):
-            new_query = self.copy_query_to_new_node(child)
-            self.results.extend(new_query.collect_results())
+        for operation in self.operation_chain:
+            self.cursor.visit(operation.perform(self.cursor.node))
+            if not self.cursor.node:
+                self.result_tree = jtt_tree.NullTreeNode()
+                return self.result_tree
+            
+        self.result_tree = self.cursor.node
+        return self.result_tree
 
 
-class TreeQuery(NodeQuery):
 
-    """
-    This class is used to build and evaluate queries against JSON objects.
-    """
-
-    def filter_key(self, predicate: str, strict: bool = False) -> "TreeQuery":
-        self.op_queue.append(operations.FilterKey(predicate, strict=strict))
-        return self
-
-    def filter_index(self, index: int, strict: bool = False) -> "TreeQuery":
-        self.op_queue.append(operations.FilterIndex(index, strict=strict))
-        return self
-
-    def get_all(self, strict: bool = False) -> "TreeQuery":
-        self.op_queue.append(operations.GetAll(strict=strict))
-        return self

--- a/tree_tools/src/jtt_query/queries.py
+++ b/tree_tools/src/jtt_query/queries.py
@@ -12,8 +12,32 @@ class NodeQueryError(Exception):
 
     pass
 
+class Cursor: 
+    """
+    This class is used to represent the current position in the tree during query processing.
+    """
+    pass
 
-class NodeQuery(jtt_tree.NodeVisitor):
+
+class QueryProcessor:
+    """
+    This class is used to evaluate queries against TreeNode objects.
+    """
+    operation_chain: operations.QueryOperationChain
+    result_tree: jtt_tree.TreeNode
+    read_tree: jtt_tree.TreeNode
+    cursor: Cursor
+    
+    def __init__(self, tree: jtt_tree.TreeNode, operation_chain: operations.QueryOperationChain) -> None:
+        self.read_tree = tree
+        self.result_tree = None
+        self.operation_chain = operation_chain
+        self.cursor = Cursor()
+    
+    pass 
+
+
+class NodeQuery:
 
     """
     This class is used to build and evaluate queries against TreeNode objects.

--- a/tree_tools/src/jtt_tree.py
+++ b/tree_tools/src/jtt_tree.py
@@ -37,7 +37,7 @@ class TreeNode:
 
     def __repr__(self) -> str:
         return TreeNode.repr_object.repr(self.value)
-    
+
     def serialize(self) -> typing.Any:
         """
         Serialize the object tree into a dictionary.
@@ -67,7 +67,7 @@ class NumberTreeNode(TreeNode):
     def __init__(self, value: typing.Union[int, float]):
         self.value = value
         self.descendant_count = 0
-        
+
 
 class BooleanTreeNode(TreeNode):
     type = NodeType.BOOLEAN
@@ -75,6 +75,7 @@ class BooleanTreeNode(TreeNode):
     def __init__(self, value: bool):
         self.value = value
         self.descendant_count = 0
+
 
 class ListTreeNode(TreeNode):
     value: typing.List[TreeNode]
@@ -99,7 +100,7 @@ class ListTreeNode(TreeNode):
             else:
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[-1].descendant_count + 1
-            
+
     def serialize(self) -> typing.List[typing.Any]:
         """
         Serialize the object tree into a list.
@@ -108,7 +109,6 @@ class ListTreeNode(TreeNode):
 
 
 class ObjectTreeNode(TreeNode):
-    
     value: typing.Dict[str, TreeNode]
     type = NodeType.OBJECT
 
@@ -131,7 +131,7 @@ class ObjectTreeNode(TreeNode):
             else:
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[k].descendant_count + 1
-            
+
     def serialize(self) -> typing.Dict[str, typing.Any]:
         """
         Serialize the object tree into a dictionary.

--- a/tree_tools/src/jtt_tree.py
+++ b/tree_tools/src/jtt_tree.py
@@ -38,9 +38,6 @@ class TreeNode:
     def __repr__(self) -> str:
         return TreeNode.repr_object.repr(self.value)
 
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        pass
-
 
 class NullTreeNode(TreeNode):
     type = NodeType.NULL
@@ -48,9 +45,6 @@ class NullTreeNode(TreeNode):
     def __init__(self):
         self.value = None
         self.descendant_count = 0
-
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_null_node(self)
 
 
 class StringTreeNode(TreeNode):
@@ -60,9 +54,6 @@ class StringTreeNode(TreeNode):
         self.value = value
         self.descendant_count = 0
 
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_string_node(self)
-
 
 class NumberTreeNode(TreeNode):
     type = NodeType.NUMBER
@@ -71,9 +62,6 @@ class NumberTreeNode(TreeNode):
         self.value = value
         self.descendant_count = 0
 
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_number_node(self)
-
 
 class BooleanTreeNode(TreeNode):
     type = NodeType.BOOLEAN
@@ -81,10 +69,6 @@ class BooleanTreeNode(TreeNode):
     def __init__(self, value: bool):
         self.value = value
         self.descendant_count = 0
-
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_boolean_node(self)
-
 
 class ListTreeNode(TreeNode):
     type = NodeType.ARRAY
@@ -109,9 +93,6 @@ class ListTreeNode(TreeNode):
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[-1].descendant_count + 1
 
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_array_node(self)
-
 
 class ObjectTreeNode(TreeNode):
     type = NodeType.OBJECT
@@ -135,36 +116,6 @@ class ObjectTreeNode(TreeNode):
             else:
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[k].descendant_count + 1
-
-    def accept_visitor(self, visitor: "NodeVisitor") -> None:
-        visitor.visit_object_node(self)
-
-
-class NodeVisitor:
-
-    """
-    Visitor pattern for tree nodes.
-    """
-
-    tree: TreeNode
-
-    def visit_null_node(self, node: NullTreeNode) -> None:
-        pass
-
-    def visit_string_node(self, node: StringTreeNode) -> None:
-        pass
-
-    def visit_number_node(self, node: NumberTreeNode) -> None:
-        pass
-
-    def visit_boolean_node(self, node: BooleanTreeNode) -> None:
-        pass
-
-    def visit_array_node(self, node: ListTreeNode) -> None:
-        pass
-
-    def visit_object_node(self, node: ObjectTreeNode) -> None:
-        pass
 
 
 def create_tree(data: typing.Dict[str, typing.Any]) -> ObjectTreeNode:

--- a/tree_tools/src/jtt_tree.py
+++ b/tree_tools/src/jtt_tree.py
@@ -37,6 +37,12 @@ class TreeNode:
 
     def __repr__(self) -> str:
         return TreeNode.repr_object.repr(self.value)
+    
+    def serialize(self) -> typing.Any:
+        """
+        Serialize the object tree into a dictionary.
+        """
+        return self.value
 
 
 class NullTreeNode(TreeNode):
@@ -61,7 +67,7 @@ class NumberTreeNode(TreeNode):
     def __init__(self, value: typing.Union[int, float]):
         self.value = value
         self.descendant_count = 0
-
+        
 
 class BooleanTreeNode(TreeNode):
     type = NodeType.BOOLEAN
@@ -71,6 +77,7 @@ class BooleanTreeNode(TreeNode):
         self.descendant_count = 0
 
 class ListTreeNode(TreeNode):
+    value: typing.List[TreeNode]
     type = NodeType.ARRAY
 
     def __init__(self, value: typing.List[TreeNode]):
@@ -92,9 +99,17 @@ class ListTreeNode(TreeNode):
             else:
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[-1].descendant_count + 1
+            
+    def serialize(self) -> typing.List[typing.Any]:
+        """
+        Serialize the object tree into a list.
+        """
+        return [v.serialize() for v in self.value]
 
 
 class ObjectTreeNode(TreeNode):
+    
+    value: typing.Dict[str, TreeNode]
     type = NodeType.OBJECT
 
     def __init__(self, value: typing.Dict[str, TreeNode]):
@@ -116,6 +131,12 @@ class ObjectTreeNode(TreeNode):
             else:
                 raise TypeError(f"Invalid type: {type(v)} for value {v}")
             self.descendant_count += self.value[k].descendant_count + 1
+            
+    def serialize(self) -> typing.Dict[str, typing.Any]:
+        """
+        Serialize the object tree into a dictionary.
+        """
+        return {k: v.serialize() for k, v in self.value.items()}
 
 
 def create_tree(data: typing.Dict[str, typing.Any]) -> ObjectTreeNode:

--- a/tree_tools/src/search.py
+++ b/tree_tools/src/search.py
@@ -8,11 +8,11 @@ from tree_tools.src.jtt_query import parsing
 def jmespath_search(query: str, tree: Dict[str, Any]) -> Dict[str, Any]:
     """
     This function is used to search for nodes in a TreeNode object using a JMESPath query string.
-    
+
     Args:
         query: The JMESPath query string to use.
         tree: The TreeNode to search.
-        
+
     Returns:
         A list of TreeNode objects that match the query.
     """
@@ -22,4 +22,3 @@ def jmespath_search(query: str, tree: Dict[str, Any]) -> Dict[str, Any]:
     processor = queries.QueryProcessor(tree, operation_chain)
     results = processor.execute()
     return results.serialize()
-    

--- a/tree_tools/src/search.py
+++ b/tree_tools/src/search.py
@@ -1,0 +1,25 @@
+from typing import Dict, Any, Optional
+
+from tree_tools.src.jtt_tree import create_tree, NullTreeNode
+from tree_tools.src.jtt_query import queries
+from tree_tools.src.jtt_query import parsing
+
+
+def jmespath_search(query: str, tree: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    This function is used to search for nodes in a TreeNode object using a JMESPath query string.
+    
+    Args:
+        query: The JMESPath query string to use.
+        tree: The TreeNode to search.
+        
+    Returns:
+        A list of TreeNode objects that match the query.
+    """
+    tree = create_tree(tree)
+    parser = parsing.JMESPathParser()
+    operation_chain = parser.parse(query)
+    processor = queries.QueryProcessor(tree, operation_chain)
+    results = processor.execute()
+    return results.serialize()
+    

--- a/tree_tools/tests/test_jsons/primitive.json
+++ b/tree_tools/tests/test_jsons/primitive.json
@@ -1,5 +1,5 @@
 {
-    "0": {
+    "foo": {
         "_id": 0,
         "name": "foo",
         "value": "bar"

--- a/tree_tools/tests/tree_tools/src/test_parsing.py
+++ b/tree_tools/tests/tree_tools/src/test_parsing.py
@@ -1,19 +1,19 @@
-import pytest 
+import pytest
 
 from tree_tools.src.jtt_query import parsing
 
-@pytest.fixture(scope='class')
+
+@pytest.fixture(scope="class")
 def parser() -> parsing.JMESPathParser:
     return parsing.JMESPathParser()
 
 
 class TestJMESPathParserValidation:
-
     def test_invalid_query_empty(self, parser: parsing.JMESPathParser):
         with pytest.raises(parsing.JMESPathValidationError) as validation_error:
-            parser.validate_query('')
+            parser.validate_query("")
         assert "cannot be empty" in str(validation_error.value)
-            
+
     @pytest.mark.parametrize(
         "query",
         [
@@ -47,29 +47,31 @@ class TestJMESPathParserValidation:
             "?",
         ],
     )
-    def test_invalid_query_start_with_special_character(self, parser: parsing.JMESPathParser, query: str):
+    def test_invalid_query_start_with_special_character(
+        self, parser: parsing.JMESPathParser, query: str
+    ):
         with pytest.raises(parsing.JMESPathValidationError) as validation_error:
             parser.validate_query(query)
-        assert "must start with a word character or a quote character" in str(validation_error.value)
+        assert "must start with a word character or a quote character" in str(
+            validation_error.value
+        )
+
 
 class TestJMESPathParserTokenization:
-    
-    
     def test_single_identifier_tokenization(self, parser: parsing.JMESPathParser):
-        parser.tokenize('foo')
-        assert parser.identifiers == ['foo']
-    
+        parser.tokenize("foo")
+        assert parser.identifiers == ["foo"]
+
     def test_identifier_tokenization(self, parser: parsing.JMESPathParser):
-        parser.tokenize('foo.bar.baz')
-        assert parser.identifiers == ['foo', 'bar', 'baz']
-        
-        
+        parser.tokenize("foo.bar.baz")
+        assert parser.identifiers == ["foo", "bar", "baz"]
+
+
 class TestJMESPathParserOperationCreation:
-    
     def test_create_query_operations(self, parser: parsing.JMESPathParser):
-        parser.identifiers = ['foo', 'bar', 'baz']
+        parser.identifiers = ["foo", "bar", "baz"]
         parser.create_query_operations()
         assert len(parser.operation_queue) == 3
         ops = [op for op in parser.operation_queue]
         assert all(isinstance(op, parsing.KeySelectOperation) for op in ops)
-        assert [op.key for op in ops] == ['foo', 'bar', 'baz']
+        assert [op.key for op in ops] == ["foo", "bar", "baz"]

--- a/tree_tools/tests/tree_tools/src/test_parsing.py
+++ b/tree_tools/tests/tree_tools/src/test_parsing.py
@@ -54,6 +54,11 @@ class TestJMESPathParserValidation:
 
 class TestJMESPathParserTokenization:
     
+    
+    def test_single_identifier_tokenization(self, parser: parsing.JMESPathParser):
+        parser.tokenize('foo')
+        assert parser.identifiers == ['foo']
+    
     def test_identifier_tokenization(self, parser: parsing.JMESPathParser):
         parser.tokenize('foo.bar.baz')
         assert parser.identifiers == ['foo', 'bar', 'baz']
@@ -65,6 +70,6 @@ class TestJMESPathParserOperationCreation:
         parser.identifiers = ['foo', 'bar', 'baz']
         parser.create_query_operations()
         assert len(parser.operation_queue) == 3
-        ops = [op for op in parser.operation_queue.operations()]
+        ops = [op for op in parser.operation_queue]
         assert all(isinstance(op, parsing.KeySelectOperation) for op in ops)
         assert [op.key for op in ops] == ['foo', 'bar', 'baz']

--- a/tree_tools/tests/tree_tools/src/test_parsing.py
+++ b/tree_tools/tests/tree_tools/src/test_parsing.py
@@ -1,0 +1,70 @@
+import pytest 
+
+from tree_tools.src.jtt_query import parsing
+
+@pytest.fixture(scope='class')
+def parser() -> parsing.JMESPathParser:
+    return parsing.JMESPathParser()
+
+
+class TestJMESPathParserValidation:
+
+    def test_invalid_query_empty(self, parser: parsing.JMESPathParser):
+        with pytest.raises(parsing.JMESPathValidationError) as validation_error:
+            parser.validate_query('')
+        assert "cannot be empty" in str(validation_error.value)
+            
+    @pytest.mark.parametrize(
+        "query",
+        [
+            "1",
+            "!",
+            "@",
+            "#",
+            "$",
+            "%",
+            "^",
+            "&",
+            "*",
+            "(",
+            ")",
+            "-",
+            "+",
+            "=",
+            "{",
+            "}",
+            "[",
+            "]",
+            "|",
+            "\\",
+            ";",
+            ":",
+            "<",
+            ">",
+            ",",
+            ".",
+            "/",
+            "?",
+        ],
+    )
+    def test_invalid_query_start_with_special_character(self, parser: parsing.JMESPathParser, query: str):
+        with pytest.raises(parsing.JMESPathValidationError) as validation_error:
+            parser.validate_query(query)
+        assert "must start with a word character or a quote character" in str(validation_error.value)
+
+class TestJMESPathParserTokenization:
+    
+    def test_identifier_tokenization(self, parser: parsing.JMESPathParser):
+        parser.tokenize('foo.bar.baz')
+        assert parser.identifiers == ['foo', 'bar', 'baz']
+        
+        
+class TestJMESPathParserOperationCreation:
+    
+    def test_create_query_operations(self, parser: parsing.JMESPathParser):
+        parser.identifiers = ['foo', 'bar', 'baz']
+        parser.create_query_operations()
+        assert len(parser.operation_queue) == 3
+        ops = [op for op in parser.operation_queue.operations()]
+        assert all(isinstance(op, parsing.KeySelectOperation) for op in ops)
+        assert [op.key for op in ops] == ['foo', 'bar', 'baz']

--- a/tree_tools/tests/tree_tools/src/test_query.py
+++ b/tree_tools/tests/tree_tools/src/test_query.py
@@ -1,11 +1,9 @@
 from tree_tools.src import jtt_query
 
 
-
 # class TestQueryProcessor:
-    
-#     # def test
 
+#     # def test
 
 
 # class TestNodeQuery:

--- a/tree_tools/tests/tree_tools/src/test_query.py
+++ b/tree_tools/tests/tree_tools/src/test_query.py
@@ -1,67 +1,74 @@
 from tree_tools.src import jtt_query
 
 
-class TestNodeQuery:
-    def test_blank_query(
-        self, fixture_sample_data_type_tree, fixture_sample_data_types
-    ):
-        """Test empty query will deliver the root node"""
 
-        query = jtt_query.TreeQuery(fixture_sample_data_type_tree)
-        results = query.collect_results()
+# class TestQueryProcessor:
+    
+#     # def test
 
-        assert len(results) == 1
-        assert results[0].value.keys() == fixture_sample_data_types.keys()
 
-    def test_single_wildcard_query(
-        self, fixture_sample_data_type_tree, fixture_sample_data_types
-    ):
-        """Test get-all query will deliver all nodes underneath the root node"""
 
-        wildcard_query = jtt_query.TreeQuery(fixture_sample_data_type_tree).get_all()
-        results = wildcard_query.collect_results()
+# class TestNodeQuery:
+#     def test_blank_query(
+#         self, fixture_sample_data_type_tree, fixture_sample_data_types
+#     ):
+#         """Test empty query will deliver the root node"""
 
-        assert len(results) == len(fixture_sample_data_types)
+#         query = jtt_query.TreeQuery(fixture_sample_data_type_tree)
+#         results = query.collect_results()
 
-    def test_not_found_query(self, fixture_sample_data_type_tree):
-        """Test that a query that doesn't match anything returns an empty list"""
+#         assert len(results) == 1
+#         assert results[0].value.keys() == fixture_sample_data_types.keys()
 
-        query = jtt_query.TreeQuery(fixture_sample_data_type_tree).filter_key(
-            "non-existent"
-        )
-        results = query.collect_results()
+#     def test_single_wildcard_query(
+#         self, fixture_sample_data_type_tree, fixture_sample_data_types
+#     ):
+#         """Test get-all query will deliver all nodes underneath the root node"""
 
-        assert not results
+#         wildcard_query = jtt_query.TreeQuery(fixture_sample_data_type_tree).get_all()
+#         results = wildcard_query.collect_results()
 
-    def test_object_key_query(self, fixture_pokemon_tree):
-        """Test that data is extracted from objects using keys"""
+#         assert len(results) == len(fixture_sample_data_types)
 
-        query = (
-            jtt_query.TreeQuery(fixture_pokemon_tree)
-            .filter_key("pokemon")
-            .get_all()
-            .filter_key("id")
-        )
+#     def test_not_found_query(self, fixture_sample_data_type_tree):
+#         """Test that a query that doesn't match anything returns an empty list"""
 
-        results = query.collect_results()
-        assert len(results) == 151
-        assert [r.value for r in results] == list(range(1, 152))
+#         query = jtt_query.TreeQuery(fixture_sample_data_type_tree).filter_key(
+#             "non-existent"
+#         )
+#         results = query.collect_results()
 
-    def test_list_index_query(self, fixture_pokemon_tree):
-        """Test that data is extracted from lists using indices"""
+#         assert not results
 
-        query = (
-            jtt_query.TreeQuery(fixture_pokemon_tree)
-            .filter_key("pokemon")
-            .get_all()
-            .filter_key("multipliers")
-            .filter_index(1)
-        )
+#     def test_object_key_query(self, fixture_pokemon_tree):
+#         """Test that data is extracted from objects using keys"""
 
-        results = query.collect_results()
-        assert len(results) == 37
-        compare_results = []
-        for p in fixture_pokemon_tree.value["pokemon"].value:
-            if p.value["multipliers"].value and len(p.value["multipliers"].value) > 1:
-                compare_results.append(p.value["multipliers"].value[1].value)
-        assert [r.value for r in results] == compare_results
+#         query = (
+#             jtt_query.TreeQuery(fixture_pokemon_tree)
+#             .filter_key("pokemon")
+#             .get_all()
+#             .filter_key("id")
+#         )
+
+#         results = query.collect_results()
+#         assert len(results) == 151
+#         assert [r.value for r in results] == list(range(1, 152))
+
+#     def test_list_index_query(self, fixture_pokemon_tree):
+#         """Test that data is extracted from lists using indices"""
+
+#         query = (
+#             jtt_query.TreeQuery(fixture_pokemon_tree)
+#             .filter_key("pokemon")
+#             .get_all()
+#             .filter_key("multipliers")
+#             .filter_index(1)
+#         )
+
+#         results = query.collect_results()
+#         assert len(results) == 37
+#         compare_results = []
+#         for p in fixture_pokemon_tree.value["pokemon"].value:
+#             if p.value["multipliers"].value and len(p.value["multipliers"].value) > 1:
+#                 compare_results.append(p.value["multipliers"].value[1].value)
+#         assert [r.value for r in results] == compare_results

--- a/tree_tools/tests/tree_tools/src/test_search.py
+++ b/tree_tools/tests/tree_tools/src/test_search.py
@@ -1,0 +1,25 @@
+import pytest
+from typing import Dict, Any
+
+from tree_tools.src.search import jmespath_search
+
+class TestSearchSampleData:
+    
+    
+    @pytest.mark.parametrize(
+        "query,expected_result",
+        [
+            ("a", 1),
+            ("b", "2"),
+            ("c", 1.5),
+            ("d", True),
+            ("e", {"f": 3, "g": "4", "h": False}),
+            ("e.f", 3),
+            ("e.g", "4"),
+            ("e.h", False),
+        ],
+    )
+    def test_search_simple_identifier_query(self, fixture_sample_data_types: Dict[str, Any], query: str, expected_result: Any):
+        
+        results = jmespath_search(query, fixture_sample_data_types)
+        assert results == expected_result

--- a/tree_tools/tests/tree_tools/src/test_search.py
+++ b/tree_tools/tests/tree_tools/src/test_search.py
@@ -3,9 +3,8 @@ from typing import Dict, Any
 
 from tree_tools.src.search import jmespath_search
 
+
 class TestSearchSampleData:
-    
-    
     @pytest.mark.parametrize(
         "query,expected_result",
         [
@@ -19,7 +18,11 @@ class TestSearchSampleData:
             ("e.h", False),
         ],
     )
-    def test_search_simple_identifier_query(self, fixture_sample_data_types: Dict[str, Any], query: str, expected_result: Any):
-        
+    def test_search_simple_identifier_query(
+        self,
+        fixture_sample_data_types: Dict[str, Any],
+        query: str,
+        expected_result: Any,
+    ):
         results = jmespath_search(query, fixture_sample_data_types)
         assert results == expected_result

--- a/tree_tools/tests/tree_tools/src/test_tree.py
+++ b/tree_tools/tests/tree_tools/src/test_tree.py
@@ -1,17 +1,18 @@
 import pytest
+from typing import Dict, Any
 
 from tree_tools.src import jtt_tree
 
 
 class TestTree:
     @pytest.mark.parametrize("data", [(None), (1), (1.0), ("a"), (True), (False), ([])])
-    def test_tree_creation_failure(self, data):
+    def test_tree_creation_failure(self, data: Any):
         """Test tree creation failure"""
 
         with pytest.raises(ValueError):
             jtt_tree.create_tree(data)
 
-    def test_tree_creation_success(self, fixture_sample_data_types):
+    def test_tree_creation_success(self, fixture_sample_data_types: Dict[str, Any]):
         """Test tree creation success -- don't auto parse strings into numbers"""
 
         tree = jtt_tree.create_tree(fixture_sample_data_types)
@@ -34,7 +35,7 @@ class TestTree:
         assert tree.value["k"].type == jtt_tree.NodeType.NULL
         assert tree.value["l"].type == jtt_tree.NodeType.OBJECT
 
-    def test_tree_children_counts(self, fixture_sample_data_types):
+    def test_tree_children_counts(self, fixture_sample_data_types: Dict[str, Any]):
         """Test tree children counts"""
 
         tree = jtt_tree.create_tree(fixture_sample_data_types)


### PR DESCRIPTION
This refactors the project to start conforming to JMESPath specifications.  Right now a user can form a query using a `Dict` object and a query string which either identifies a single identifier or a path of identifiers separated by periods (`.`)

Identifiers for now must be letters or underscores. 
```python
    file = open("tree_tools/tests/test_jsons/primitive.json")
    data = json.load(file)
    results = jmespath_search("foo._id", data)
```
